### PR TITLE
Update JsonStringStaticizerTask to support AGP 7+

### DIFF
--- a/src/main/groovy/com/stefanhalus/jsonstring/staticizer/JsonStringStaticizerTask.groovy
+++ b/src/main/groovy/com/stefanhalus/jsonstring/staticizer/JsonStringStaticizerTask.groovy
@@ -11,7 +11,7 @@ import org.gradle.api.tasks.incremental.IncrementalTaskInputs
 import java.util.function.Consumer
 
 public class JsonStringStaticizerTask extends DefaultTask {
-    //@InputDirectory
+    @InputDirectory
     File inputDir
 
     @OutputDirectory


### PR DESCRIPTION
After updating the android gradle pluggin to version 7.0.0 or above we're getting following error in KA2.0 and JA2.0
  - In plugin 'com.stefanhalus.jsonstring.staticizer' type 'com.stefanhalus.jsonstring.staticizer.JsonStringStaticizerTask' property 'inputDir' is missing an input or output annotation.